### PR TITLE
Support folders and duplicate names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-    <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
 
   <name>Jenkins Gogs plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsPayloadProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsPayloadProcessor.java
@@ -45,7 +45,7 @@ public class GogsPayloadProcessor {
     try {
       saveCtx = SecurityContextHolder.getContext();
 
-      Jenkins instance = Jenkins.getInstance();
+      Jenkins instance = Jenkins.getActiveInstance();
       if (instance!=null) {
         ACL acl = instance.getACL();
         acl.impersonate(ACL.SYSTEM);

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsUtils.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.gogs;
+
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+
+class GogsUtils {
+
+	private GogsUtils() {
+	}
+
+	/**
+	 * Search in Jenkins for a item with type T based on the job name
+	 * @param jobName job to find, for jobs inside a folder use : {@literal <folder>/<folder>/<jobName>}
+	 * @return the Job matching the given name, or {@code null} when not found
+	 */
+	static <T extends Item> T find(String jobName, Class<T> type) {
+		Jenkins jenkins = Jenkins.getInstance();
+		// direct search, can be used to find folder based items <folder>/<folder>/<jobName>
+		T item = jenkins.getItemByFullName(jobName, type);
+		if (item == null) {
+			// not found in a direct search, search in all items since the item might be in a folder but given without folder structure
+			// (to keep it backwards compatible)
+			for (T allItem : jenkins.getAllItems(type)) {
+				 if (allItem.getName().equals(jobName)) {
+				 	item = allItem;
+				 	break;
+				 }
+			}
+		}
+		return item;
+	}
+}

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsUtils.java
@@ -14,7 +14,7 @@ class GogsUtils {
 	 * @return the Job matching the given name, or {@code null} when not found
 	 */
 	static <T extends Item> T find(String jobName, Class<T> type) {
-		Jenkins jenkins = Jenkins.getInstance();
+		Jenkins jenkins = Jenkins.getActiveInstance();
 		// direct search, can be used to find folder based items <folder>/<folder>/<jobName>
 		T item = jenkins.getItemByFullName(jobName, type);
 		if (item == null) {

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -69,6 +69,8 @@ public class GogsWebHook implements UnprotectedRootAction {
      * Receives the HTTP POST request send by Gogs.
      *
      * @param req request
+     * @param rsp response
+     * @throws IOException problem while parsing
      */
     public void doIndex(StaplerRequest req, StaplerResponse rsp)  throws IOException {
       GogsResults result = new GogsResults();

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -114,7 +114,6 @@ public class GogsWebHook implements UnprotectedRootAction {
         String gSecret = jsonObject.getString("secret");  /* Secret provided by Gogs    */
 
         String jSecret = null;
-        /* secret is stored in the properties of Job */
         boolean foundJob = false;
 
         SecurityContext saveCtx = SecurityContextHolder.getContext();
@@ -123,16 +122,15 @@ public class GogsWebHook implements UnprotectedRootAction {
             ACL acl = jenkins.getACL();
             acl.impersonate(ACL.SYSTEM);
 
-            for (Job job : jenkins.getAllItems(Job.class)) {
-                foundJob = job.getName().equals(jobName);
-                if (foundJob) {
-                    final GogsProjectProperty property = (GogsProjectProperty) job.getProperty(GogsProjectProperty.class);
-                    if (property != null) { /* only if Gogs secret is defined on the job */
-                        jSecret = property.getGogsSecret(); /* Secret provided by Jenkins */
-                    }
-                    /* no need to go through all other jobs */
-                    break;
-                }
+            Job job = GogsUtils.find(jobName, Job.class);
+
+            if (job != null) {
+                foundJob = true;
+				/* secret is stored in the properties of Job */
+				final GogsProjectProperty property = (GogsProjectProperty) job.getProperty(GogsProjectProperty.class);
+				if (property != null) { /* only if Gogs secret is defined on the job */
+					jSecret = property.getGogsSecret(); /* Secret provided by Jenkins */
+				}
             }
         } finally {
             SecurityContextHolder.setContext(saveCtx);


### PR DESCRIPTION
use Jenkins.getItemByFullName to search for a job so we can support folder structures and duplicate names inside folders, for backward compatibility we also search through all items when not found (old behaviour)

This will make it easy to find items in folders like in #10 