### PR TITLE
Fix branches with slash

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -41,6 +41,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -200,13 +201,9 @@ public class GogsWebHook implements UnprotectedRootAction {
 
         // job not found by name, perhaps it's a multibranch job so try by `job/branch`
         String ref = (String)webhookPayload.get("ref");
-        String[] components = ref.split("/");
+        String branchName = urlEncode(ref.replace("refs/heads/", ""));
 
-        if(components.length == 0)
-            return null;
-
-        String branch = components[components.length-1];
-        return GogsUtils.find(jobName + "/" + branch, Job.class);
+        return GogsUtils.find(jobName + "/" + branchName, Job.class);
     }
 
     /**
@@ -224,6 +221,15 @@ public class GogsWebHook implements UnprotectedRootAction {
       resp.setStatus(result.getStatus());
       resp.addHeader("Content-Type","application/json");
       resp.getWriter().print(json.toString());
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // this can't really happen, UTF-8 should always be supported
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
#20 was merged yesterday, supporting Multibranch projects which is great!

However for my use case it was not working because I typically prefix my branches with `feature/` or `bugfix/` etc. This was not supported by the code handling the webhook for two reasons:

1. It derived the branch name from the Git ref by taking the part after the last `/` character. This means that `refs/heads/feature/test-branch` would be converted into `test-branch` where it should have been `feature/test-branch`.

2. Jenkins internally URL encodes job names. In Multibranch projects job names are derived from the SCM branch names. This means that for a branch named `feature/test-branch` the corresponding Jenkins job will be named `feature%252Ftest-branch` and should be passed to `jenkins.getItemByFullName` in that form.

This PR fixes both of these problems and in the process cleaned up some duplication introduced by #20.