### PR TITLE
Fix for branches that contains a slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Example how your the webhook in Gogs should look like:
 This project has some integration tests available. For more details see the [dedicated readme](about_integration_tests.md).
 
 ### Change Log
+#### Version 1.0.14 (Apr 4, 2018)
+- Fixes `job not found` if slashes are used in branch [[GH_ISSUE#36](https://github.com/jenkinsci/gogs-webhook-plugin/issues/36)/[PR#40](https://github.com/jenkinsci/gogs-webhook-plugin/pull/40)].
+
 #### Version 1.0.13 (Mar 16, 2018)
 - Fixes `job not found` if folders are used [[GH_ISSUE#36](https://github.com/jenkinsci/gogs-webhook-plugin/issues/36)/[PR#37](https://github.com/jenkinsci/gogs-webhook-plugin/pull/37)].
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -13,7 +14,7 @@
 
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
     <java.level.test>8</java.level.test>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -42,7 +42,9 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -185,7 +187,13 @@ public class GogsWebHook implements UnprotectedRootAction {
                 } else {
                     String ref = (String) jsonObject.get("ref");
                     String[] components = ref.split("/");
-                    ref = components[components.length - 1];
+                    if (components.length > 3) {
+                        /* refs contains branch/tag with a slash */
+                        List<String> test = Arrays.asList(ref.split("/"));
+                        ref = String.join("%2F", test.subList(2, test.size()));
+                    } else {
+                        ref = components[components.length - 1];
+                    }
 
                     job = GogsUtils.find(jobName + "/" + ref, Job.class);
 


### PR DESCRIPTION
This PR fixes the `job not found` problem with the Multibranch plugin. Branches with a slash in the name where not working properly because the split was done on a slash and only the last element was used.