### PR TITLE
branch filter support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
@@ -58,6 +58,10 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
         return this.gogsBranchFilter;
     }
 
+    public boolean getHasBranchFilter() {
+        return gogsBranchFilter != null && gogsBranchFilter.length() > 0;
+    }
+
     private static final Logger LOGGER = Logger.getLogger(GogsWebHook.class.getName());
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
@@ -62,6 +62,13 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
         return gogsBranchFilter != null && gogsBranchFilter.length() > 0;
     }
 
+    public boolean filterBranch(String ref) {
+        if (gogsBranchFilter != null && gogsBranchFilter.length() > 0 && !gogsBranchFilter.equals("*")) {
+            return ref == null || ref.length() == 0 || ref.endsWith(gogsBranchFilter);
+        }
+        return true;
+    }
+
     private static final Logger LOGGER = Logger.getLogger(GogsWebHook.class.getName());
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
@@ -97,7 +97,7 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
 
         @Override
         public String getDisplayName() {
-            return "Gogs Secret";
+            return "Gogs Project Property";
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsProjectProperty.java
@@ -37,11 +37,13 @@ import java.util.logging.Logger;
 public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
     private final String gogsSecret;
     private final boolean gogsUsePayload;
+    private final String gogsBranchFilter;
 
     @DataBoundConstructor
-    public GogsProjectProperty(String gogsSecret, boolean gogsUsePayload) {
+    public GogsProjectProperty(String gogsSecret, boolean gogsUsePayload, String gogsBranchFilter) {
         this.gogsSecret = gogsSecret;
         this.gogsUsePayload = gogsUsePayload;
+        this.gogsBranchFilter = gogsBranchFilter;
     }
 
     public String getGogsSecret() {
@@ -52,6 +54,10 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
         return this.gogsUsePayload;
     }
 
+    public String getGogsBranchFilter() {
+        return this.gogsBranchFilter;
+    }
+
     private static final Logger LOGGER = Logger.getLogger(GogsWebHook.class.getName());
 
     @Extension
@@ -59,6 +65,7 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
         public static final String GOGS_PROJECT_BLOCK_NAME = "gogsProject";
         private String gogsSecret;
         private boolean gogsUsePayload;
+        private String gogsBranchFilter;
 
         public String getGogsSecret() {
             return gogsSecret;
@@ -66,6 +73,10 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
 
         public boolean getGogsUsePayload() {
             return gogsUsePayload;
+        }
+
+        public String getGogsBranchFilter() {
+            return gogsBranchFilter;
         }
 
         public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) {
@@ -76,8 +87,10 @@ public class GogsProjectProperty extends JobProperty<Job<?, ?>> {
             if (tpp != null) {
                 LOGGER.finest(formData.toString());
                 LOGGER.finest(tpp.gogsSecret);
+                LOGGER.finest(tpp.gogsBranchFilter);
 
                 gogsSecret = tpp.gogsSecret;
+                gogsBranchFilter = tpp.gogsBranchFilter;
             }
             return tpp;
         }

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -168,8 +168,11 @@ public class GogsWebHook implements UnprotectedRootAction {
             }
 
             String jSecret = null;
+            String branchFilter = null;
             boolean foundJob = false;
-            payloadProcessor.setPayload("ref", jsonObject.getString("ref"));
+
+            String ref = (String) jsonObject.getString("ref");
+            payloadProcessor.setPayload("ref", ref);
             payloadProcessor.setPayload("before", jsonObject.getString("before"));
 
             SecurityContext saveCtx = ACL.impersonate(ACL.SYSTEM);
@@ -183,9 +186,9 @@ public class GogsWebHook implements UnprotectedRootAction {
                     final GogsProjectProperty property = (GogsProjectProperty) job.getProperty(GogsProjectProperty.class);
                     if (property != null) { /* only if Gogs secret is defined on the job */
                         jSecret = property.getGogsSecret(); /* Secret provided by Jenkins */
+                        branchFilter = property.getGogsBranchFilter(); /* branch filter provided by jenkins */
                     }
                 } else {
-                    String ref = (String) jsonObject.get("ref");
                     String[] components = ref.split("/");
                     if (components.length > 3) {
                         /* refs contains branch/tag with a slash */
@@ -203,6 +206,7 @@ public class GogsWebHook implements UnprotectedRootAction {
                         final GogsProjectProperty property = (GogsProjectProperty) job.getProperty(GogsProjectProperty.class);
                         if (property != null) { /* only if Gogs secret is defined on the job */
                             jSecret = property.getGogsSecret(); /* Secret provided by Jenkins */
+                            branchFilter = property.getGogsBranchFilter(); /* branch filter provided by jenkins */
                         }
                     }
                 }
@@ -224,10 +228,20 @@ public class GogsWebHook implements UnprotectedRootAction {
                 }
             }
 
+            // filter branch, not ref not match branch filter, skip trigger.
+            boolean isRefMatched = false;
+            if (branchFilter != null && branchFilter != "*" && branchFilter.length() > 0) {
+                isRefMatched = ref == null || ref.length() == 0 || ref.endsWith(branchFilter);
+            }
+
             if (!foundJob) {
                 String msg = String.format("Job '%s' is not defined in Jenkins", jobName);
                 result.setStatus(404, msg);
                 LOGGER.warning(msg);
+            } else if (!isRefMatched) {
+                String msg = String.format("received ref ('%s') is not matched with branch filter in job '%s' ('%s')", ref, jobName, branchFilter);
+                result.setStatus(200, msg);
+                LOGGER.info(msg);
             } else if (isNullOrEmpty(jSecret) && isNullOrEmpty(gSecret)) {
                 /* No password is set in Jenkins and Gogs, run without secrets */
                 result = payloadProcessor.triggerJobs(jobName, gogsDelivery);

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -229,7 +229,7 @@ public class GogsWebHook implements UnprotectedRootAction {
             }
 
             // filter branch, not ref not match branch filter, skip trigger.
-            boolean isRefMatched = false;
+            boolean isRefMatched = true;
             if (branchFilter != null && branchFilter != "*" && branchFilter.length() > 0) {
                 isRefMatched = ref == null || ref.length() == 0 || ref.endsWith(branchFilter);
             }

--- a/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/gogs/GogsWebHook.java
@@ -230,7 +230,7 @@ public class GogsWebHook implements UnprotectedRootAction {
 
             // filter branch, not ref not match branch filter, skip trigger.
             boolean isRefMatched = true;
-            if (branchFilter != null && branchFilter != "*" && branchFilter.length() > 0) {
+            if (branchFilter != null && !branchFilter.equals("*") && branchFilter.length() > 0) {
                 isRefMatched = ref == null || ref.length() == 0 || ref.endsWith(branchFilter);
             }
 

--- a/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
@@ -7,7 +7,7 @@
       </f:entry>
     </f:optionalBlock>
     <f:optionalBlock title="Branch Filter" inline="true" checked="${instance.gogsBranchFilter != null}">
-      <f:entry title="${%BranchFilter}">
+      <f:entry title="${%BranchFilter}" description="default: master">
         <f:textbox default="master" field="gogsBranchFilter" />
       </f:entry>
     </f:optionalBlock>

--- a/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
@@ -6,9 +6,9 @@
         <f:password field="gogsSecret" />
       </f:entry>
     </f:optionalBlock>
-    <f:optionalBlock title="Branch Filter" inline="true" checked="${instance.gogsBranchFilter != null}">
-      <f:entry title="${%BranchFilter}" description="default: master">
-        <f:textbox default="master" field="gogsBranchFilter" />
+    <f:optionalBlock title="Branch Filter" inline="true" checked="${instance.hasBranchFilter}">
+      <f:entry title="${%BranchFilter}">
+        <f:textbox field="gogsBranchFilter" />
       </f:entry>
     </f:optionalBlock>
   </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gogs/GogsProjectProperty/config.jelly
@@ -6,5 +6,10 @@
         <f:password field="gogsSecret" />
       </f:entry>
     </f:optionalBlock>
+    <f:optionalBlock title="Branch Filter" inline="true" checked="${instance.gogsBranchFilter != null}">
+      <f:entry title="${%BranchFilter}">
+        <f:textbox default="master" field="gogsBranchFilter" />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/gogs/GogsWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gogs/GogsWebHookTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -229,6 +230,33 @@ public class GogsWebHookTest {
         String expectedOutput = "No payload or URI contains invalid entries.";
         isExpectedOutput(uniqueFile, expectedOutput);
 
+        log.info("Test succeeded.");
+    }
+
+    @Test
+    public void whenJobBranchNotMatchMustReturnError() throws Exception {
+        String[][] test_vals = {
+            {null, "master", "true"},
+            {null, "dev", "true"},
+            {"", "master", "true"},
+            {"", "dev", "true"},
+            {"*", "master", "true"},
+            {"*", "dev", "true"},
+            {"dev", "master", "false"},
+            {"dev", "dev", "true"},
+            {"master", "master", "true"},
+            {"master", "dev", "false"},
+        };
+
+        for (int i = 0; i < test_vals.length; ++i) {
+            String filter = test_vals[i][0];
+            String ref = test_vals[i][1];
+            boolean ret = Boolean.parseBoolean(test_vals[i][2]);
+
+            GogsProjectProperty property = new GogsProjectProperty(null, false, filter);
+            assertSame(String.format("branch filter check failed for [%s -> %s]", ref, filter), ret, property.filterBranch(ref));
+        }
+        
         log.info("Test succeeded.");
     }
 


### PR DESCRIPTION
## description

add a branch filter to jenkins job, only push event with matched ref name should trigger job.

## Types of changes

- [ x] New feature (non-breaking change which adds functionality)

## Further comments

- add `"branch filter"` field in job config, default value set to `"master"`
- if set `"branch filter"` to empty or `"*"`, means to handle any ref in this job
- otherwise, only trigger job while ref name ends with value of `"branch filter"`
